### PR TITLE
ci: fix deploy workflow to only trigger on version tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: deploy
 
 on:
   push:
-    branches: [develop]
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
@@ -10,6 +9,9 @@ on:
 jobs:
   deploy-pypi:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6
@@ -28,6 +30,3 @@ jobs:
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `branches: [develop]` trigger that caused deploy to run on every push, failing because non-release commits cannot publish to PyPI (fixes [run #23893133166](https://github.com/lan496/hsnf/actions/runs/23893133166))
- Switch from API token auth to PyPI Trusted Publishers (OIDC) for tokenless publishing

## Setup required
After merging, configure Trusted Publishers on PyPI:
1. Go to https://pypi.org/manage/project/hsnf/settings/publishing/
2. Add GitHub Actions publisher: owner=`lan496`, repo=`hsnf`, workflow=`deploy.yml`, environment=`pypi`
3. Create a `pypi` environment in GitHub repo settings (Settings > Environments)

## Test plan
- [ ] Verify no deploy job triggers on push to `develop`
- [ ] Next tag push (`v*.*.*`) triggers the deploy workflow
- [ ] Trusted Publishers OIDC auth works with PyPI

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)